### PR TITLE
Allow `bazel info` to ignore Starlark options

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/BUILD
@@ -338,6 +338,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/transports",
         "//src/main/java/com/google/devtools/build/lib/clock",
         "//src/main/java/com/google/devtools/build/lib/cmdline",
+        "//src/main/java/com/google/devtools/build/lib/cmdline:LabelValidator",
         "//src/main/java/com/google/devtools/build/lib/collect",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/concurrent",

--- a/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.cmdline.LabelValidator;
+import com.google.devtools.build.lib.cmdline.LabelValidator.BadLabelException;
 import com.google.devtools.build.lib.cmdline.TargetParsingException;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.events.Reporter;
@@ -219,6 +221,11 @@ public class StarlarkOptionsParser {
   /**
    * Separates out any Starlark options from the given list
    *
+   * <p>This method doesn't go through the trouble to actually load build setting targets and verify
+   * they are build settings, it just assumes all strings that look like they could be build
+   * settings, aka are formatted like a flag and can parse out to a proper label, are build
+   * settings. Use actual parsing functions above to do full build setting verification.
+   *
    * @param list List of strings from which to parse out starlark options
    * @return Returns a pair of string lists. The first item contains the list of starlark options
    *     that were removed; the second contains the remaining string from the original list.
@@ -228,7 +235,25 @@ public class StarlarkOptionsParser {
     ImmutableList.Builder<String> keep = ImmutableList.builder();
     ImmutableList.Builder<String> remove = ImmutableList.builder();
     for (String name : list) {
-      ((name.startsWith("--//") || name.startsWith("--no//")) ? remove : keep).add(name);
+      // Check if the string is a flag and trim off "--" if so.
+      if (!name.startsWith("--")) {
+        keep.add(name);
+        continue;
+      }
+      String potentialStarlarkFlag = name.substring(2);
+      // Check if the string uses the "no" prefix for setting boolean flags to false, trim
+      // off "no" if so.
+      if (name.startsWith("no")) {
+        potentialStarlarkFlag = potentialStarlarkFlag.substring(2);
+      }
+      // Check if we can properly parse the (potentially trimmed) string as a label. If so, count
+      // as starlark flag, else count as regular residue.
+      try {
+        LabelValidator.validateAbsoluteLabel(potentialStarlarkFlag);
+        remove.add(name);
+      } catch (BadLabelException e) {
+        keep.add(name);
+      }
     }
     return Pair.of(remove.build(), keep.build());
   }

--- a/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
@@ -14,7 +14,6 @@
 
 package com.google.devtools.build.lib.runtime;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.devtools.build.lib.analysis.config.CoreOptionConverters.BUILD_SETTING_CONVERTERS;
 import static com.google.devtools.build.lib.packages.RuleClass.Builder.STARLARK_BUILD_SETTING_DEFAULT_ATTR_NAME;
 import static com.google.devtools.build.lib.packages.Type.BOOLEAN;
@@ -226,13 +225,12 @@ public class StarlarkOptionsParser {
    */
   public static Pair<ImmutableList<String>, ImmutableList<String>> removeStarlarkOptions(
       List<String> list) {
-    ImmutableList<String> removed =
-        list.stream()
-            .filter(r -> r.startsWith("--//") || r.startsWith("--no//"))
-            .collect(toImmutableList());
-    ImmutableList<String> kept =
-        list.stream().filter(r -> !removed.contains(r)).collect(toImmutableList());
-    return Pair.of(removed, kept);
+    ImmutableList.Builder<String> keep = ImmutableList.builder();
+    ImmutableList.Builder<String> remove = ImmutableList.builder();
+    for (String name : list) {
+      ((name.startsWith("--//") || name.startsWith("--no//")) ? remove : keep).add(name);
+    }
+    return Pair.of(remove.build(), keep.build());
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
@@ -14,6 +14,7 @@
 
 package com.google.devtools.build.lib.runtime;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.devtools.build.lib.analysis.config.CoreOptionConverters.BUILD_SETTING_CONVERTERS;
 import static com.google.devtools.build.lib.packages.RuleClass.Builder.STARLARK_BUILD_SETTING_DEFAULT_ATTR_NAME;
 import static com.google.devtools.build.lib.packages.Type.BOOLEAN;
@@ -214,6 +215,24 @@ public class StarlarkOptionsParser {
       throw new OptionsParsingException("Unrecognized option: " + targetToBuild);
     }
     return buildSetting;
+  }
+
+  /**
+   * Separates out any Starlark options from the given list
+   *
+   * @param list List of strings from which to parse out starlark options
+   * @return Returns a pair of string lists. The first item contains the list of starlark options
+   *     that were removed; the second contains the remaining string from the original list.
+   */
+  public static Pair<ImmutableList<String>, ImmutableList<String>> removeStarlarkOptions(
+      List<String> list) {
+    ImmutableList<String> removed =
+        list.stream()
+            .filter(r -> r.startsWith("--//") || r.startsWith("--no//"))
+            .collect(toImmutableList());
+    ImmutableList<String> kept =
+        list.stream().filter(r -> !removed.contains(r)).collect(toImmutableList());
+    return Pair.of(removed, kept);
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/InfoCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/InfoCommand.java
@@ -35,6 +35,7 @@ import com.google.devtools.build.lib.util.AbruptExitException;
 import com.google.devtools.build.lib.util.DetailedExitCode;
 import com.google.devtools.build.lib.util.ExitCode;
 import com.google.devtools.build.lib.util.InterruptedFailureDetails;
+import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.build.lib.util.io.OutErr;
 import com.google.devtools.common.options.Option;
 import com.google.devtools.common.options.OptionDocumentationCategory;
@@ -169,7 +170,17 @@ public class InfoCommand implements BlazeCommand {
         }
       }
 
-      List<String> residue = optionsParsingResult.getResidue();
+      Pair<ImmutableList<String>, ImmutableList<String>> starlarkOptionsAndResidue =
+          StarlarkOptionsParser.removeStarlarkOptions(optionsParsingResult.getResidue());
+      ImmutableList<String> removedStarlarkOptions = starlarkOptionsAndResidue.getFirst();
+      ImmutableList<String> residue = starlarkOptionsAndResidue.getSecond();
+      if (!removedStarlarkOptions.isEmpty()) {
+        env.getReporter()
+            .handle(
+                Event.warn(
+                    "Blaze info does not support starlark options. Ignoring options: "
+                        + removedStarlarkOptions));
+      }
       if (residue.size() > 1) {
         String message = "at most one key may be specified";
         env.getReporter().handle(Event.error(message));

--- a/src/test/java/com/google/devtools/build/lib/skylark/BUILD
+++ b/src/test/java/com/google/devtools/build/lib/skylark/BUILD
@@ -24,6 +24,7 @@ java_test(
         "//src/test/java/com/google/devtools/build/lib:test_runner",
     ],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib:runtime",
         "//src/main/java/com/google/devtools/build/lib:syntax",
         "//src/main/java/com/google/devtools/build/lib/actions",
         "//src/main/java/com/google/devtools/build/lib/analysis:actions/parameter_file_write_action",

--- a/src/test/java/com/google/devtools/build/lib/skylark/StarlarkOptionsParsingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skylark/StarlarkOptionsParsingTest.java
@@ -17,7 +17,10 @@ package com.google.devtools.build.lib.skylark;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.build.lib.runtime.StarlarkOptionsParser;
 import com.google.devtools.build.lib.skylark.util.StarlarkOptionsTestCase;
+import com.google.devtools.build.lib.util.Pair;
 import com.google.devtools.common.options.OptionsParsingException;
 import com.google.devtools.common.options.OptionsParsingResult;
 import org.junit.Test;
@@ -317,5 +320,24 @@ public class StarlarkOptionsParsingTest extends StarlarkOptionsTestCase {
     OptionsParsingResult result = parseStarlarkOptions("--//test:my_int_setting=15");
 
     assertThat(result.getStarlarkOptions().get("//test:my_int_setting")).isEqualTo(15);
+  }
+
+  @Test
+  public void testRemoveStarlarkOptionsWorks() throws Exception {
+    Pair<ImmutableList<String>, ImmutableList<String>> residueAndStarlarkOptions =
+        StarlarkOptionsParser.removeStarlarkOptions(
+            ImmutableList.of(
+                "--//local/starlark/option",
+                "--@some_repo//external/starlark/option",
+                "--@//main/repo/option",
+                "some-random-residue",
+                "--mangled//external/starlark/option"));
+    assertThat(residueAndStarlarkOptions.getFirst())
+        .containsExactly(
+            "--//local/starlark/option",
+            "--@some_repo//external/starlark/option",
+            "--@//main/repo/option");
+    assertThat(residueAndStarlarkOptions.getSecond())
+        .containsExactly("some-random-residue", "--mangled//external/starlark/option");
   }
 }


### PR DESCRIPTION
This changeset brings the following commits to make `bazel info` not fail with an error like `ERROR: unknown key: '--//bazel/custom_rules/somerule:custom_opt=...`:

- https://github.com/bazelbuild/bazel/commit/2ec58f60ae1732f4c1d09330c4583050ac8d1f46 (Allow blaze info to ignore starlark options)
- https://github.com/bazelbuild/bazel/commit/2f06f8037bc50f4d7c83e94a608a0ca714b0d4c4 (Use linear formula for sorting starlark options out of residue)
- https://github.com/bazelbuild/bazel/commit/69d4acef9c4f6546955e549a7ffaab8dbcfbc9d2 (Update sorting out of starlark flags to also identify external repo starlark flags)