### PR TITLE
Respect Starlark options with values in `removeStarlarkOptions()`

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/StarlarkOptionsParser.java
@@ -246,6 +246,11 @@ public class StarlarkOptionsParser {
       if (name.startsWith("no")) {
         potentialStarlarkFlag = potentialStarlarkFlag.substring(2);
       }
+      // Check if the string contains a value, trim off the value if so.
+      int equalsIdx = potentialStarlarkFlag.indexOf('=');
+      if (equalsIdx > 0) {
+        potentialStarlarkFlag = potentialStarlarkFlag.substring(0, equalsIdx);
+      }
       // Check if we can properly parse the (potentially trimmed) string as a label. If so, count
       // as starlark flag, else count as regular residue.
       try {

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/InfoCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/InfoCommand.java
@@ -27,6 +27,7 @@ import com.google.devtools.build.lib.runtime.BlazeCommandResult;
 import com.google.devtools.build.lib.runtime.BlazeRuntime;
 import com.google.devtools.build.lib.runtime.Command;
 import com.google.devtools.build.lib.runtime.CommandEnvironment;
+import com.google.devtools.build.lib.runtime.StarlarkOptionsParser;
 import com.google.devtools.build.lib.server.FailureDetails;
 import com.google.devtools.build.lib.server.FailureDetails.BuildConfiguration.Code;
 import com.google.devtools.build.lib.server.FailureDetails.FailureDetail;

--- a/src/test/java/com/google/devtools/build/lib/skylark/StarlarkOptionsParsingTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skylark/StarlarkOptionsParsingTest.java
@@ -328,16 +328,26 @@ public class StarlarkOptionsParsingTest extends StarlarkOptionsTestCase {
         StarlarkOptionsParser.removeStarlarkOptions(
             ImmutableList.of(
                 "--//local/starlark/option",
+                "--//local/starlark/option=with_value",
                 "--@some_repo//external/starlark/option",
+                "--@some_repo//external/starlark/option=with_value",
                 "--@//main/repo/option",
+                "--@//main/repo/option=with_value",
                 "some-random-residue",
-                "--mangled//external/starlark/option"));
+                "--mangled//external/starlark/option",
+                "--mangled//external/starlark/option=with_value"));
     assertThat(residueAndStarlarkOptions.getFirst())
         .containsExactly(
             "--//local/starlark/option",
+            "--//local/starlark/option=with_value",
             "--@some_repo//external/starlark/option",
-            "--@//main/repo/option");
+            "--@some_repo//external/starlark/option=with_value",
+            "--@//main/repo/option",
+            "--@//main/repo/option=with_value");
     assertThat(residueAndStarlarkOptions.getSecond())
-        .containsExactly("some-random-residue", "--mangled//external/starlark/option");
+        .containsExactly(
+            "some-random-residue",
+            "--mangled//external/starlark/option",
+            "--mangled//external/starlark/option=with_value");
   }
 }


### PR DESCRIPTION
Related: https://github.com/bazelbuild/bazel/issues/11301
(Partially fixed in https://github.com/bazelbuild/bazel/commit/2ec58f60ae1732f4c1d09330c4583050ac8d1f46)

Motivation:

`StarlarkOptionsParser.removeStarlarkOptions()` doesn't take the case
into account where the specified Starlark option has a value, e.g.
`--//my_rules/custom_flags:foo=bar`.

Modifications:

- Do not pass a Starlark flag value when validating the flag name.

Result:

`bazel info` does not fail anymore when `.bazelrc` contains a statement
like the following:

    build --//my_rules/custom_flags:foo=bar