### PR TITLE
Add a flag to limit per-test output in --test_output=errors|all

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/test/TestStrategy.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/test/TestStrategy.java
@@ -321,7 +321,10 @@ public abstract class TestStrategy implements TestActionContext {
       if (testResultData.getStatus() != BlazeTestStatus.INCOMPLETE
           && TestLogHelper.shouldOutputTestLog(executionOptions.testOutput, isPassed)) {
         TestLogHelper.writeTestLog(
-            testLog, testName, actionExecutionContext.getFileOutErr().getOutputStream());
+            testLog,
+            testName,
+            actionExecutionContext.getFileOutErr().getOutputStream(),
+            executionOptions.maxTestOutputBytes);
       }
     } finally {
       if (isPassed) {

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -257,6 +257,22 @@ public class ExecutionOptions extends OptionsBase {
   public TestOutputFormat testOutput;
 
   @Option(
+      name = "max_test_output_bytes",
+      defaultValue = "-1",
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {
+        OptionEffectTag.TEST_RUNNER,
+        OptionEffectTag.TERMINAL_OUTPUT,
+        OptionEffectTag.EXECUTION
+      },
+      help =
+          "Specifies maximum per-test-log size that can be emitted when --test_summary is 'errors' "
+              + "or 'all'. Useful for avoiding overwhelming the output with excessively noisy test "
+              + "output. The test header is included in the log size. Negative values imply no "
+              + "limit. Output is all or nothing.")
+  public int maxTestOutputBytes;
+
+  @Option(
       name = "test_summary",
       defaultValue = "short",
       converter = TestSummaryFormat.Converter.class,

--- a/src/main/java/com/google/devtools/build/lib/runtime/TerminalTestResultNotifier.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/TerminalTestResultNotifier.java
@@ -204,7 +204,12 @@ public class TerminalTestResultNotifier implements TestResultNotifier {
       if (summary.isLocalActionCached()
           && TestLogHelper.shouldOutputTestLog(testOutput,
               TestResult.isBlazeTestStatusPassed(summary.getStatus()))) {
-        TestSummaryPrinter.printCachedOutput(summary, testOutput, printer, testLogPathFormatter);
+        TestSummaryPrinter.printCachedOutput(
+            summary,
+            testOutput,
+            printer,
+            testLogPathFormatter,
+            executionOptions.maxTestOutputBytes);
       }
     }
 

--- a/src/main/java/com/google/devtools/build/lib/runtime/TestSummaryPrinter.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/TestSummaryPrinter.java
@@ -44,14 +44,13 @@ public class TestSummaryPrinter {
     String getPathStringToPrint(Path path);
   }
 
-  /**
-   * Print the cached test log to the given printer.
-   */
+  /** Print the cached test log to the given printer. */
   public static void printCachedOutput(
       TestSummary summary,
       TestOutputFormat testOutput,
       AnsiTerminalPrinter printer,
-      TestLogPathFormatter testLogPathFormatter) {
+      TestLogPathFormatter testLogPathFormatter,
+      int maxTestOutputBytes) {
 
     String testName = summary.getLabel().toString();
     List<String> allLogs = new ArrayList<>();
@@ -70,7 +69,7 @@ public class TestSummaryPrinter {
     if (TestLogHelper.shouldOutputTestLog(testOutput, false)) {
       for (Path path : summary.getFailedLogs()) {
         try {
-          TestLogHelper.writeTestLog(path, testName, printer.getOutputStream());
+          TestLogHelper.writeTestLog(path, testName, printer.getOutputStream(), maxTestOutputBytes);
         } catch (IOException e) {
           printer.printLn("==================== Could not read test output for " + testName);
           LoggingUtil.logToRemote(Level.WARNING, "Error while reading test log", e);
@@ -82,7 +81,7 @@ public class TestSummaryPrinter {
     if (TestLogHelper.shouldOutputTestLog(testOutput, true)) {
       for (Path path : summary.getPassedLogs()) {
         try {
-          TestLogHelper.writeTestLog(path, testName, printer.getOutputStream());
+          TestLogHelper.writeTestLog(path, testName, printer.getOutputStream(), maxTestOutputBytes);
         } catch (Exception e) {
           printer.printLn("==================== Could not read test output for " + testName);
           LoggingUtil.logToRemote(Level.WARNING, "Error while reading test log", e);


### PR DESCRIPTION
The limit is all-or-nothing - if the test log is too big it's not printed at
all.

Known shortcomings...
- `--experimental_replay_action_out_err` will cache the omitted message - this
  is an existing bug (https://github.com/bazelbuild/bazel/issues/11365).
- Uncached test output has a (mostly silent) 1G upper bound from UiEventHandler,
  this is an existing limitation and it's highly unlikely anyone is doing
  anything useful with 1G+ of test output anyway...
- It'd be nice to print the path of the file we would have streamed to the
  console, alas wiring the output-relative path pretty-printing logic through
  the uncached path proved rather onerous. Instead, for now, rely on the test
  name and generous limits being sufficient.

PiperOrigin-RevId: 329367191