### PR TITLE
Support selectors dict concatenation

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/Type.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Type.java
@@ -515,6 +515,15 @@ public abstract class Type<T> {
     }
 
     @Override
+    public Map<KeyT, ValueT> concat(Iterable<Map<KeyT, ValueT>> iterable) {
+      ImmutableMap.Builder<KeyT, ValueT> output = ImmutableMap.builder();
+      for (Map<KeyT, ValueT> map: iterable){
+        output.putAll(map);
+      }
+      return output.build();
+    }
+
+    @Override
     public Map<KeyT, ValueT> getDefaultValue() {
       return empty;
     }

--- a/src/test/java/com/google/devtools/build/lib/packages/BuildTypeTest.java
+++ b/src/test/java/com/google/devtools/build/lib/packages/BuildTypeTest.java
@@ -436,6 +436,38 @@ public class BuildTypeTest {
   }
 
   @Test
+  public void testSelectorListMap() throws Exception {
+    Object selector1 = new SelectorValue(ImmutableMap.of("//conditions:a",
+        ImmutableMap.of("//a:a", "a"), "//conditions:b", ImmutableMap.of("//b:b", "b")), "");
+    Object selector2 = new SelectorValue(ImmutableMap.of("//conditions:c",
+        ImmutableMap.of("//c:c", "c"), "//conditions:d", ImmutableMap.of("//d:d", "d")), "");
+    BuildType.SelectorList<Map<Label, String>> selectorList =
+        new BuildType.SelectorList<Map<Label, String>>(
+            ImmutableList.of(selector1, selector2),
+            null,
+            labelConversionContext,
+            BuildType.LABEL_KEYED_STRING_DICT);
+
+    assertThat(selectorList.getOriginalType()).isEqualTo(BuildType.LABEL_KEYED_STRING_DICT);
+    assertThat(selectorList.getKeyLabels())
+        .containsExactly(
+            Label.parseAbsolute("//conditions:a", ImmutableMap.of()),
+            Label.parseAbsolute("//conditions:b", ImmutableMap.of()),
+            Label.parseAbsolute("//conditions:c", ImmutableMap.of()),
+            Label.parseAbsolute("//conditions:d", ImmutableMap.of()));
+
+    List<Selector<Map<Label, String>>> selectors = selectorList.getSelectors();
+    assertThat(selectors.get(0).getEntries().entrySet())
+        .containsExactlyElementsIn(
+            ImmutableMap.of(
+                Label.parseAbsolute("//conditions:a", ImmutableMap.of()),
+                ImmutableMap.of(Label.create("@//a", "a"), "a"),
+                Label.parseAbsolute("//conditions:b", ImmutableMap.of()),
+                ImmutableMap.of(Label.create("@//b", "b"), "b"))
+                .entrySet());
+  }
+
+  @Test
   public void testSelectorListMixedTypes() throws Exception {
     Object selector1 =
         new SelectorValue(ImmutableMap.of("//conditions:a", ImmutableList.of("//a:a")), "");


### PR DESCRIPTION
Allow concatenating dictionaries with select of dictionaries. Currently, there is no way to do this. Note: This supports `<dict> + <select>` but does not support `<dict>.update(<select>)`