### PR TITLE
fix: possible null pointer dereference

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLine.java
+++ b/src/main/java/com/google/devtools/build/lib/rules/cpp/LinkCommandLine.java
@@ -891,7 +891,7 @@ public final class LinkCommandLine extends CommandLine {
     Artifact inputArtifact = input.getArtifact();
     PathFragment libDir = inputArtifact.getExecPath().getParentDirectory();
     if (rpathRoot != null
-        && !libDir.equals(solibDir)
+        && !solibDir.equals(libDir)
         && (runtimeSolibDir == null || !runtimeSolibDir.equals(libDir))) {
       String dotdots = "";
       PathFragment commonParent = solibDir;


### PR DESCRIPTION
In file: LinkCommandLine.java, class LinkCommandLine there is a method addDynamicInputLinkOptions that, there is a potential Null pointer dereference while calling the equals method.

```java
PathFragment libDir = inputArtifact.getExecPath().getParentDirectory();
```

The method `getParentDirectory()` can return `null` value. 
```java
public PathFragment getParentDirectory() {
    return segments.length == 0 ? null : subFragment(0, segments.length - 1);
}
```

now if the returned value is null then it later can raise a `NullPointerException`
```java
!libDir.equals(solibDir)
```

but changing the order it can be avoided or a null check on `libDir` should be done to avoid this kind error. like
```java
!solibDir.equals(libDir)
```
or
```java
libDir != null
```


##### Sponsorship and Support

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.